### PR TITLE
Upgrade dependencies

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,22 +1,21 @@
-source 'https://rubygems.org'
+source "https://rubygems.org"
 
 gemspec
 
 group :test, :development do
-  gem 'gem-release'
-  gem 'pry'
-  gem 'rerun', '~> 0.9.0'
-  gem 'yard'
-  gem 'webmock'
+  gem "gem-release", "~> 2.0.1"
+  gem "pry", "~> 0.12.2"
+  gem "rerun", "~> 0.9.0"
+  gem "webmock", "~> 3.5.1"
+  gem "yard", "~> 0.9.18"
 end
 
 group :test do
-  gem 'rspec'
-  gem 'rack-test'
-  gem 'rack', '~> 1'
-  gem 'codeclimate-test-reporter'
-  gem 'grape', '~> 0.11.0'
-  gem 'activesupport', '~> 4'
-  gem 'grape-entity', '~> 0.4.5'
+  gem "activesupport", "~> 4.2.11.1"
+  gem "codeclimate-test-reporter", "~> 1.0.9"
+  gem "grape", "~> 1.1.0"
+  gem "grape-entity", "~> 0.4.8"
+  gem "rack", "~> 1.6.11"
+  gem "rack-test", "~> 1.1.0"
+  gem "rspec", "~> 3.8.0"
 end
-

--- a/lib/swaggable/grape_adapter.rb
+++ b/lib/swaggable/grape_adapter.rb
@@ -36,7 +36,7 @@ module Swaggable
     def substitute_parameters_in_path path, grape_endpoint
       path = path.dup
 
-      grape_endpoint.route_compiled.names.each do |name|
+      names(grape_endpoint).each do |name|
         path.gsub!(/:#{name}/, "{#{name}}")
       end
 
@@ -51,8 +51,8 @@ module Swaggable
         p.type = options[:type].downcase.to_sym if options[:type]
         p.required = options[:required]
         p.description = options[:desc]
-        p.location = if grape_endpoint.route_compiled.names.include? name
-                       :path 
+        p.location = if names(grape_endpoint).include? name
+                       :path
                      else
                        :query
                      end
@@ -84,6 +84,14 @@ module Swaggable
           r.status = status
           r.description = desc
         end
+      end
+    end
+
+    def names(grape_endpoint)
+      if grape_endpoint.route_compiled
+        grape_endpoint.route_compiled.names
+      else
+        grape_endpoint.pattern.to_regexp.names
       end
     end
   end


### PR DESCRIPTION
# Description

The purpose of this PR is to make swaggable compatible with grape version 1.1.0 as in grape 1.1.0 `route_compiled` in `grape_endpoint` has been replaced by `pattern.to_regexp`.

Also in this PR I upgraded grape to remove security vulnerability.

# Tests passing?
Yes , they are passing locally with 
```
$ bundle exec rspec
```
