### PR TITLE
Fix forwardable errors

### DIFF
--- a/lib/swaggable/errors/validations_collection.rb
+++ b/lib/swaggable/errors/validations_collection.rb
@@ -1,3 +1,5 @@
+require "forwardable"
+
 module Swaggable
   module Errors
     class ValidationsCollection < Validation

--- a/lib/swaggable/mime_types_collection.rb
+++ b/lib/swaggable/mime_types_collection.rb
@@ -1,3 +1,5 @@
+require "forwardable"
+
 module Swaggable
   class MimeTypesCollection
     include Enumerable


### PR DESCRIPTION
# Description

The idea is to require `forwardable` module where necessary to avoid initialized constants problems.